### PR TITLE
Switch to use VPN_ from environment, instead of reading /etc/resolv.conf, and some other minor changes.

### DIFF
--- a/90-update-resolv.conf
+++ b/90-update-resolv.conf
@@ -22,7 +22,7 @@
 DNSMASQ_RESOLV=/etc/dnsmasq.d/resolv-${CONNECTION_UUID}.conf
 
 # for debugging
-#set > /tmp/90-update-resolv.log.$(date +%s)
+set > /tmp/90-update-resolv.log
 
 function write_dnsmasq_header
 {
@@ -30,7 +30,8 @@ function write_dnsmasq_header
  then
   echo "# ${DNSMASQ_RESOLV} generated on $(date)" > ${DNSMASQ_RESOLV}
   echo "# Generator: ${0}" >> ${DNSMASQ_RESOLV}
-  echo "# Connection: ${CONNECTION_UUID}" >> ${DNSMASQ_RESOLV}
+  echo "# Connection NAME: ${CONNECTION_ID}" >> ${DNSMASQ_RESOLV}
+  echo "# Connection UUID: ${CONNECTION_UUID}" >> ${DNSMASQ_RESOLV}
   echo "#" >> ${DNSMASQ_RESOLV}
  fi
 }
@@ -55,18 +56,22 @@ function create_dnsmasq_config_env
  done
 }
 
-function create_dnsmasq_config_from_resolv_conf
+function create_dnsmasq_vpn_config
 {
  local NS
  local DOMAIN=""
 
  write_dnsmasq_header
 
- for DOMAIN in ${IP4_DOMAINS}
+ echo "DHCP4_DOMAIN_SEARCH: ${DHCP4_DOMAIN_SEARCH}"
+ echo "DHCP4_DOMAIN_NAME_SERVERS: ${DHCP4_DOMAIN_NAME_SERVERS}"
+
+ for DOMAIN in ${VPN_IP4_DOMAINS}
  do
+  # make sure the DOMAIN is not from an other config
   grep -q -E "# IP4_DOMAINS:.* ${DOMAIN}" /etc/dnsmasq.d/resolv-*.conf && continue
 
-  for NS in $(awk '/^nameserver/ {print $2}' /etc/resolv.conf)
+  for NS in ${VPN_IP4_NAMESERVERS}
   do
    # make sure the NS is not from an other config
    grep -q "[=/]${NS}\$" /etc/dnsmasq.d/resolv-*.conf && continue
@@ -93,7 +98,7 @@ function remove_stale_configs
   # in case of a wildcard error
   [ -e "${CONF}" ] || continue
 
-  UUID=$(awk '/^# Connection: / {print $3}' ${CONF})
+  UUID=$(awk '/^# Connection UUID: / {print $4}' ${CONF})
   if ! ( nmcli -t -f UUID connection show --active | grep -q "^${UUID}\$" )
   then
    rm -f ${CONF}
@@ -103,7 +108,14 @@ function remove_stale_configs
 
 function reload_dnsmasq
 {
- cat /etc/resolv.conf.dnsmasq > /etc/resolv.conf
+ cat << _EOF > /etc/resolv.conf
+# /etc/resolv.conf generated on $(date)
+# Generator: $0
+#
+# dnsmasq used for per connection dns servers.
+# See /etc/dnsmasq.d/resolve-*.conf
+nameserver 127.0.0.1
+_EOF
  [ -n "${DHCP4_DOMAIN_SEARCH}" ] && echo "search ${DHCP4_DOMAIN_SEARCH}" >> /etc/resolv.conf
  # "killall -HUP dnsmasq" is not sufficient for new files
  /sbin/service dnsmasq restart 2>&1 > /dev/null
@@ -117,7 +129,7 @@ case "$2" in
   ;;
  "vpn-up")
   remove_stale_configs
-  create_dnsmasq_config_from_resolv_conf
+  create_dnsmasq_vpn_config
   reload_dnsmasq
   ;;
  "down")

--- a/90-update-resolv.conf
+++ b/90-update-resolv.conf
@@ -63,12 +63,9 @@ function create_dnsmasq_vpn_config
 
  write_dnsmasq_header
 
- echo "DHCP4_DOMAIN_SEARCH: ${DHCP4_DOMAIN_SEARCH}"
- echo "DHCP4_DOMAIN_NAME_SERVERS: ${DHCP4_DOMAIN_NAME_SERVERS}"
-
  for DOMAIN in ${VPN_IP4_DOMAINS}
  do
-  # make sure the DOMAIN is not from an other config
+  # make sure the DOMAIN is not from an other config??
   grep -q -E "# IP4_DOMAINS:.* ${DOMAIN}" /etc/dnsmasq.d/resolv-*.conf && continue
 
   for NS in ${VPN_IP4_NAMESERVERS}

--- a/90-update-resolv.conf
+++ b/90-update-resolv.conf
@@ -22,7 +22,7 @@
 DNSMASQ_RESOLV=/etc/dnsmasq.d/resolv-${CONNECTION_UUID}.conf
 
 # for debugging
-set > /tmp/90-update-resolv.log
+#set > /tmp/90-update-resolv.log.$(date +%s)
 
 function write_dnsmasq_header
 {

--- a/90-update-resolv.conf
+++ b/90-update-resolv.conf
@@ -56,12 +56,12 @@ function create_dnsmasq_config_env
  done
 }
 
-function create_dnsmasq_vpn_config
+function dnsmasq_config_vpn_use_nm_vars
 {
  local NS
  local DOMAIN=""
 
- write_dnsmasq_header
+ echo -e "# Generated from NetworkManager VPN_ prefix vars\n#" >> ${DNSMASQ_RESOLV}
 
  for DOMAIN in ${VPN_IP4_DOMAINS}
  do
@@ -78,6 +78,44 @@ function create_dnsmasq_vpn_config
    echo "server=/${DOMAIN}/${NS}" >> ${DNSMASQ_RESOLV}
   done
  done
+}
+
+function dnsmasq_config_vpn_from_resolv_conf
+{
+ local NS
+ local DOMAIN=""
+
+ echo -e "# Generated from resolv.conf\n#" >> ${DNSMASQ_RESOLV}
+
+ for DOMAIN in ${IP4_DOMAINS}
+ do
+  # make sure the DOMAIN is not from an other config??
+  grep -q -E "# IP4_DOMAINS:.* ${DOMAIN}" /etc/dnsmasq.d/resolv-*.conf && continue
+
+  for NS in $(awk '/^nameserver/ {print $2}' /etc/resolv.conf)
+  do
+   # make sure the NS is not from an other config
+   grep -q "[=/]${NS}\$" /etc/dnsmasq.d/resolv-*.conf && continue
+   # FIXME: skip any IPv6 nameservers, this is sad
+   grep -q ':' <<< "${NS}" && continue
+
+   echo "server=/${DOMAIN}/${NS}" >> ${DNSMASQ_RESOLV}
+  done
+ done
+}
+
+function create_dnsmasq_config_vpn
+{
+ write_dnsmasq_header
+
+ # Try to use NetworkManager VPN_ variables
+ # Fallback to parsing resolv.conf if VPN_ vars are not set
+ if [ -n "${VPN_IP4_DOMAINS}" ] && [ -n ${VPN_IP4_NAMESERVERS} ]
+  then
+   dnsmasq_config_vpn_use_nm_vars
+  else
+   dnsmasq_config_vpn_from_resolv_conf
+ fi
 }
 
 function remove_dnsmasq_config
@@ -105,6 +143,7 @@ function remove_stale_configs
 
 function reload_dnsmasq
 {
+ cp /etc/resolv.conf /tmp/resolv.conf-${CONNECTION_UUID}
  cat << _EOF > /etc/resolv.conf
 # /etc/resolv.conf generated on $(date)
 # Generator: $0
@@ -126,7 +165,7 @@ case "$2" in
   ;;
  "vpn-up")
   remove_stale_configs
-  create_dnsmasq_vpn_config
+  create_dnsmasq_config_vpn
   reload_dnsmasq
   ;;
  "down")

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ server should (mostly) not require additional dependencies.
 1. Copy the `90-update-resolv.conf` script to
    `/etc/NetworkManager/dispatcher.d/`.
 
-2. Create the `/etc/dnsmasq.d/localhost.conf with the following content
+2. Create the `/etc/dnsmasq.d/localhost.conf` with the following content
 
    ```
    no-resolv

--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@ server should (mostly) not require additional dependencies.
 
 ## Installation
 
-1. Copy `resolv.conf.dnsmasq` to `/etc/`.
-
-2. Copy the `90-update-resolv.conf` script to
+1. Copy the `90-update-resolv.conf` script to
    `/etc/NetworkManager/dispatcher.d/`.
+
+2. Create the `/etc/dnsmasq.d/localhost.conf with the following content
+
+   ```
+   no-resolv
+   no-poll
+   interface=lo
+   no-dhcp-interface=lo
+   bind-interfaces
+   ```
 
 3. Install and enable `dnsmasq`:
 

--- a/nm-separate-dns.spec
+++ b/nm-separate-dns.spec
@@ -1,7 +1,7 @@
 %define		commit 1a46825a7d8734f4d1315455e4de8dfc9813f716
 
 Name:		nm-separate-dns
-Version:	20141225
+Version:	20150117
 Release:	1%{?dist}
 Summary:	Generate dnsmasq config files per connection to separate dns queries
 
@@ -26,16 +26,16 @@ and need to connect to a VPN which serves a different private domain.
 
 
 %install
-install -D -m 0644 resolv.conf.dnsmasq %{buildroot}/etc/resolv.conf.dnsmasq
 install -D -m 0755 90-update-resolv.conf %{buildroot}/etc/NetworkManager/dispatcher.d/90-update-resolv.conf
 
 
 %files
 %doc README.md LICENSE
-%config(noreplace) /etc/resolv.conf.dnsmasq
 /etc/NetworkManager/dispatcher.d/90-update-resolv.conf
 
 
 %changelog
+* Sat Jan 17 2015 Harald Jensas <hjensas@redhat.com> - 20150117-1
+- Removed /etc/resolv.conf.dnsmasq, replace by cat << EOF in 90-update-resolv.conf
 * Thu Dec 25 2014 Niels de Vos <niels@nixpanic.net> - 20141225-1
 - Initial packaging

--- a/resolv.conf.dnsmasq
+++ b/resolv.conf.dnsmasq
@@ -1,1 +1,0 @@
-nameserver 127.0.0.1


### PR DESCRIPTION
I could'nt get this working on Fedora 21 intially, I ended up changeing the script to use the VPN_ variables available, instead of parsing the /etc/resolv.conf to get search domains and nameservers for vpn connection. 
