### PR TITLE
Fix check for duplicate domains

### DIFF
--- a/90-update-resolv.conf
+++ b/90-update-resolv.conf
@@ -68,7 +68,7 @@ function dnsmasq_config_vpn_use_nm_vars
  for DOMAIN in ${VPN_IP4_DOMAINS}
  do
   # make sure the DOMAIN is not from an other config??
-  grep -q -E "# IP4_DOMAINS:.* ${DOMAIN}" /etc/dnsmasq.d/resolv-*.conf && continue
+  grep -q -E "server=/${DOMAIN}/.*" /etc/dnsmasq.d/resolv-*.conf && continue
 
   for NS in ${VPN_IP4_NAMESERVERS}
   do


### PR DESCRIPTION
This patch fixes situation when the domain of your
e.g. WiFi connection is equal to the domain of your
VPN connection (as in our office).
It checks whether the domain was actually specified
for a private nameserver.