### PR TITLE
Don't overwrite debug logs

### DIFF
--- a/90-update-resolv.conf
+++ b/90-update-resolv.conf
@@ -24,7 +24,7 @@ DNSMASQ_RESOLV=/etc/dnsmasq.d/resolv-${CONNECTION_UUID}.conf
 # for debugging, set to a non-empty string to enable
 #DEBUG=enabled
 
-[ -z "${DEBUG}" ] || set > /tmp/90-update-resolv.log.$(date +%s)
+[ -z "${DEBUG}" ] || set > /tmp/90-update-resolv.log.$(date +%s.%N)
 
 function write_dnsmasq_header
 {


### PR DESCRIPTION
This commit assures that debug logs are not overwritten when 2 connections
are dispatched within one second by using nanoseconds in the names
of the files.